### PR TITLE
Merged tl credited

### DIFF
--- a/src/main/scala/common/Configs.scala
+++ b/src/main/scala/common/Configs.scala
@@ -23,7 +23,7 @@ class WithNShuttleCores(
       core = ShuttleCoreParams(retireWidth = retireWidth),
       btb = Some(BTBParams(nEntries=32)),
       icache = Some(
-        ICacheParams(rowBits = -1, nSets=64, nWays=8, fetchBytes=2*4)
+        ICacheParams(rowBits = -1, nSets=64, nWays=1, fetchBytes=2*4)
       ))
     List.tabulate(n) (i => ShuttleTileAttachParams(
       shuttle.copy(tileId = i + idOffset),

--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -318,7 +318,7 @@ class ShuttleTileModuleImp(outer: ShuttleTile) extends BaseTileModuleImp(outer)
     core.io.rocc.busy <> (cmdRouter.io.busy || outer.roccs.map(_.module.io.busy).reduce(_ || _))
     core.io.rocc.interrupt := outer.roccs.map(_.module.io.interrupt).reduce(_ || _)
     val roccCSRIOs = outer.roccs.map(_.module.io.csrs)
-    (core.io.rocc.csrs zip roccCSRIOs.flatten).foreach { t => t._2 := t._1 }
+    (core.io.rocc.csrs zip roccCSRIOs.flatten).foreach { t => t._2 <> t._1 }
   }
 
 

--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -37,7 +37,7 @@ case class ShuttleTileParams(
   btb: Option[BTBParams] = Some(BTBParams()),
   tcm: Option[ShuttleTCMParams] = None,
   tileId: Int = 0,
-  tileBeatBytes: Int = 8,
+  tileBeatBytes: Int = 16,
   boundaryBuffers: Boolean = false) extends InstantiableTileParams[ShuttleTile]
 {
   require(icache.isDefined)

--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -67,7 +67,8 @@ case class ShuttleCrossingParams(
   slave: HierarchicalElementSlavePortParams = HierarchicalElementSlavePortParams(where=SBUS),
   mmioBaseAddressPrefixWhere: TLBusWrapperLocation = SBUS,
   resetCrossingType: ResetCrossingType = NoResetCrossing(),
-  forceSeparateClockReset: Boolean = false
+  forceSeparateClockReset: Boolean = false,
+  forceMergedCreditedTLCrossings: Boolean = false
 ) extends HierarchicalElementCrossingParamsLike
 
 case class ShuttleTileAttachParams(

--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -123,6 +123,7 @@ class ShuttleTile private(
 
   val frontend = LazyModule(new ShuttleFrontend(tileParams.icache.get, tileId))
   (tlMasterXbar.node
+    := TLBuffer()
     := tcmAdjusterNode
     := TLBuffer()
     := TLWidthWidget(tileParams.icache.get.fetchBytes)
@@ -132,6 +133,7 @@ class ShuttleTile private(
   val nPTWPorts = 2 + roccs.map(_.nPTWPorts).sum
   val dcache = LazyModule(new ShuttleDCache(tileId, ShuttleDCacheParams())(p))
   (tlMasterXbar.node
+    := TLBuffer()
     := tcmAdjusterNode
     := TLBuffer()
     := TLWidthWidget(tileParams.dcache.get.rowBits/8)
@@ -153,7 +155,7 @@ class ShuttleTile private(
         devOverride = Some(device),
         devName = Some(s"Core $tileId TCM bank $b")
       ))
-      tcm.node := TLFragmenter(shuttleParams.tileBeatBytes, p(CacheBlockBytes)) := tlSlaveXbar.node
+      tcm.node := TLFragmenter(shuttleParams.tileBeatBytes, p(CacheBlockBytes)) := TLBuffer() := tlSlaveXbar.node
     }
     val replicationSize = (1 << log2Ceil(p(NumTiles))) * tcmParams.size
     val tcm_master_replicator = LazyModule(new RegionReplicator(ReplicatedRegion(

--- a/src/main/scala/common/Tile.scala
+++ b/src/main/scala/common/Tile.scala
@@ -138,7 +138,7 @@ class ShuttleTile private(
     := dcache.node)
 
   val vector_unit = shuttleParams.core.vector.map(v => LazyModule(v.build(p)))
-  vector_unit.foreach(vu => tlMasterXbar.node :=* tcmAdjusterNode :=* vu.atlNode)
+  vector_unit.foreach(vu => tlMasterXbar.node :=* TLBuffer() :=* tcmAdjusterNode :=* vu.atlNode)
   vector_unit.foreach(vu => tlOtherMastersNode :=* vu.tlNode)
 
   shuttleParams.tcm.foreach { tcmParams => DisableMonitors { implicit p =>

--- a/src/main/scala/dmem/DCache.scala
+++ b/src/main/scala/dmem/DCache.scala
@@ -17,8 +17,8 @@ case class ShuttleDCacheParams(
   nWays: Int = 4,
   nMSHRs: Int = 4,
   nMMIOs: Int = 1,
-  nBanks: Int = 4,
-  nTagBanks: Int = 4,
+  nBanks: Int = 1,
+  nTagBanks: Int = 1,
   singlePorted: Boolean = true,
   replayQueueSize: Int = 6,
   nWbs: Int = 2

--- a/src/main/scala/exu/Core.scala
+++ b/src/main/scala/exu/Core.scala
@@ -25,6 +25,7 @@ class ShuttleCore(tile: ShuttleTile, edge: TLEdgeOut)(implicit p: Parameters) ex
   with HasFPUParameters
 {
   val shuttleParams = coreParams.asInstanceOf[ShuttleCoreParams]
+  val nTotalRoCCCSRs = tile.roccCSRs.flatten.size
 
   val io = IO(new Bundle {
     val hartid = Input(UInt(hartIdLen.W))
@@ -33,7 +34,7 @@ class ShuttleCore(tile: ShuttleTile, edge: TLEdgeOut)(implicit p: Parameters) ex
     val dmem = new ShuttleDCacheIO
     val ptw = Flipped(new DatapathPTWIO())
     val ptw_tlb = new TLBPTWIO
-    val rocc = Flipped(new RoCCCoreIO())
+    val rocc = Flipped(new RoCCCoreIO(nTotalRoCCCSRs))
     val trace = Output(new TraceBundle)
     val fcsr_rm = Output(UInt(FPConstants.RM_SZ.W))
     val vector = if (usingVector) Some(Flipped(new ShuttleVectorCoreIO)) else None


### PR DESCRIPTION
### Description

In this PR, the following changes have been made across multiple files:

- Added new configuration class `WithShuttleCluster` for configuring a Shuttle cluster.
- Updated `ShuttleTileParams` to change `tileBeatBytes` to 16 from 8.
- Added a new field `forceMergedCreditedTLCrossings` in `ShuttleCrossingParams`.
- Updated `ShuttleDCacheParams` to modify the number of banks and tag banks to 1 from 4.

These changes are made to enhance and adjust the configurations related to the Shuttle system.

- Added a new configuration class `WithShuttleCluster` to configure a Shuttle cluster.
- Updated `ShuttleTileParams` to change the `tileBeatBytes` value from 8 to 16.
- Added a new field `forceMergedCreditedTLCrossings` in `ShuttleCrossingParams`.
- Updated `ShuttleDCacheParams` to modify the number of banks and tag banks to 1 from 4.